### PR TITLE
ci(e2e): fix kind load on new node images and the authorize reaction

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,8 +27,11 @@ jobs:
     # COLLABORATOR) comments exactly "/launch e2e" on a pull request. This gates
     # the secret-using e2e to maintainers and is the approval step for fork PRs.
     permissions:
-      pull-requests: read
-      issues: write # to react to the launch comment
+      # The launch comment lives on a PR, so reacting to it (the rocket
+      # acknowledgement) needs pull-requests: write; issues: write is not
+      # sufficient for a PR comment. This also covers reading the PR head SHA.
+      pull-requests: write
+      issues: write
     if: >-
       github.event_name == 'workflow_dispatch' ||
       ( github.event.issue.pull_request != null &&

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -84,6 +84,13 @@ jobs:
           # from the latest kind release, and an older kind binary fails to load
           # into them with "unknown containerd config version: 4".
           kind_version="$(curl -sSfL -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)"
+          # jq prints the literal "null" (and -e/-f do not catch it) if the field
+          # is ever missing; fail fast here rather than feeding "null" into the
+          # kind-action version input and getting a confusing "download kind null".
+          if [ -z "${kind_version}" ] || [ "${kind_version}" = "null" ]; then
+            echo "could not resolve the latest kind release tag (got '${kind_version}')" >&2
+            exit 1
+          fi
           echo "kind_version=${kind_version}" >> "${GITHUB_OUTPUT}"
     outputs:
       k8s_versions: ${{ steps.matrix.outputs.k8s_versions }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -69,13 +69,22 @@ jobs:
       - uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0 # v0.6
       - id: matrix
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           k8s_cycles="$(curl -sSfL https://endoflife.date/api/kubernetes.json | jq -rc '[sort_by(.releaseDate) | reverse | .[0:4] | .[].cycle]')"
           kind_versions="$(crane ls docker.io/kindest/node | jq -sRrc --argjson cycles "${k8s_cycles}" 'split("\n") | [.[] | match("^v((\\d+\\.\\d+)\\.\\d+)$").captures | {cycle: .[1].string, version: .[0].string}] | group_by(.cycle) | [.[] | .[-1] | {(.cycle): {"version": .version}}] | reduce .[] as $item ({}; . *= $item) | . as $versions | [$cycles | .[] | select($versions[.] != null) | $versions[.].version]')"
           echo "k8s_versions=${kind_versions}" >> "${GITHUB_OUTPUT}"
+          # Pin the kind binary to its latest release so `kind load` understands
+          # the newest node images the matrix selects. The node tags above come
+          # from the latest kind release, and an older kind binary fails to load
+          # into them with "unknown containerd config version: 4".
+          kind_version="$(curl -sSfL -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)"
+          echo "kind_version=${kind_version}" >> "${GITHUB_OUTPUT}"
     outputs:
       k8s_versions: ${{ steps.matrix.outputs.k8s_versions }}
+      kind_version: ${{ steps.matrix.outputs.kind_version }}
 
   e2e:
     needs: [authorize, k8s_versions]
@@ -100,6 +109,7 @@ jobs:
       - name: Create kind cluster (k8s ${{ matrix.k8s_version }})
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: ${{ needs.k8s_versions.outputs.kind_version }}
           cluster_name: kind
           node_image: kindest/node:v${{ matrix.k8s_version }}
           wait: 2m


### PR DESCRIPTION
## What

Two fixes that make the e2e workflow actually runnable.

## 1. kind binary tracks its latest release

The matrix discovers the newest `kindest/node` tags dynamically. For k8s 1.34/1.35/1.36 those images are built by kind v0.32.0 (containerd config v4), but `helm/kind-action@v1.14.0` bundles an older kind binary that fails to load them with `unknown containerd config version: 4 (supported versions: 2 and 3)` (run [28198677023](https://github.com/alekc/gitlab-runner-operator/actions/runs/28198677023)). The `k8s_versions` job now resolves the latest kind release tag (via the releases API, authenticated with the job token to avoid rate limits) and passes it to the action's `version` input, so the binary always matches the node images the matrix selects and stays self-correcting on future kind releases.

## 2. authorize can react to the launch comment

The comment-triggered `authorize` job failed with `Resource not accessible by integration` (403) when posting the rocket reaction. The launch comment is a pull-request comment, so reacting to it needs `pull-requests: write`; the job only had `issues: write`. `workflow_dispatch` was unaffected because it skips the reaction path. The job now has `pull-requests: write` (which also covers reading the PR head).

Both are workflow-file changes, so they only take effect once merged to `main`, since comment and dispatch triggers run the default-branch copy of the workflow.
